### PR TITLE
(Re)Create DLS data groups only if needed

### DIFF
--- a/src/mot-encoder.cpp
+++ b/src/mot-encoder.cpp
@@ -872,7 +872,7 @@ void packMscDG(unsigned char* b, MSCDG* msc, unsigned short int* bsize)
 
 void writeDLS(int output_fd, const char* dls_file, int padlen, uint8_t charset)
 {
-    char dlstext[MAXDLS];
+    char dlstext[MAXDLS + 1];
     int dlslen;
     int i;
 


### PR DESCRIPTION
If the DLS text remains the same, we can reuse the existing data groups which were created earlier.
This also fixes the problem that the toggle bit is flipped everytime - despite transmitting the same DLS text or not.
