### PR TITLE
Make DLS conversion from (ATM only) UTF-8 to EBU Latin optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,17 +211,19 @@ can also read *mot-encoder* data.
 
 This is an ongoing development. Make sure you use the same pad length option
 for *mot-encoder* and the audio encoder. Only some pad lengths are supported,
-please see *mot-encoder*'s help. Only pad lengths 34, 42 and 58 seem to be
-working with some receivers, 23 and 26 appear to be broken.
+please see *mot-encoder*'s help.
 
 Character Sets
 --------------
 When *mot-encoder* is launched with the default character set encoding, it assumes
 that the DLS text in the file is encoded in UTF-8, and will convert it according to
-the DAB standard.
+the DAB standard to the EBU Latin based character set encoding.
 
-If you set the character set encoding to anything else, *mot-encoder* will not perform
-any conversion, and it is your responsibility to ensure the encoding is valid.
+If you set the character set encoding to anything else (except: EBU Latin based,
+which needs no conversion), *mot-encoder* will abort, as it does not support
+any other conversion than from UTF-8 to EBU Latin based.
+You can also use the -C option to transmit the untouched DLS text. In this case,
+it is your responsibility to ensure the encoding is valid.
 
 Known Limitations
 -----------------

--- a/src/mot-encoder.cpp
+++ b/src/mot-encoder.cpp
@@ -298,7 +298,7 @@ void usage(char* name)
                     "                          ID =  2: EBU Latin based core, Arabic, Hebrew, Cyrillic and Greek\n"
                     "                          ID =  3: ISO Latin Alphabet No 2\n"
                     "                          ID = 15: ISO/IEC 10646 using UTF-8\n"
-                    "                          Default: 0\n"
+                    "                          Default: 15\n"
                     " -C, --dls-to-ebu       Convert each DLS text to Complete EBU Latin based repertoire\n"
                     "                          character set encoding (currently only from UTF-8).\n"
                     " -R, --raw-slides       Do not process slides. Integrity checks and resizing\n"
@@ -320,7 +320,7 @@ int main(int argc, char *argv[])
     bool erase_after_tx = false;
     int  sleepdelay = SLEEPDELAY_DEFAULT;
     bool raw_slides = false;
-    int  charset = CHARSET_COMPLETE_EBU_LATIN;
+    int  charset = CHARSET_UTF8;
     bool dls_to_ebu = false;
 
     const char* dir = NULL;

--- a/src/mot-encoder.cpp
+++ b/src/mot-encoder.cpp
@@ -262,7 +262,7 @@ CharsetConverter charset_converter;
 typedef std::vector<uint8_t> pad_t;
 static std::deque<pad_t> dls_pads;
 static bool dls_toggle = false;
-std::string dlstext_prev(MAXDLS + 1, ' ');
+std::string dlstext_prev = "";
 
 
 static int verbose = 0;
@@ -982,7 +982,8 @@ void writeDLS(int output_fd, const std::string& dls_file, int padlen, uint8_t ch
         ss << dls_lines[i];
     }
     std::string dlstext = ss.str();
-    using namespace std;
+    if (dlstext.size() > MAXDLS)
+        dlstext.resize(MAXDLS);
 
     if (dls_to_ebu)
         charset = CHARSET_COMPLETE_EBU_LATIN;


### PR DESCRIPTION
This (re-)introduces the ability to use DLS texts already having EBU Latin based charset (e.g. DAB retransmission of an FM station having RDS).
The conversion from (ATM only) UTF-8 to EBU Latin based must now be enabled via parameter. If enabled, the charset parameter only affects the DLS text input.
