### PR TITLE
Quick-fix to be able to build with gcc 5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This package:
     cd fdk-aac-dabplus
     ./bootstrap
     ./configure
-    make
+    make CXXFLAGS="-Wno-narrowing -std=gnu++11"
     sudo make install
 
 If you want to use the JACK and libVLC input, please use

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This package:
     cd fdk-aac-dabplus
     ./bootstrap
     ./configure
-    make CXXFLAGS="-Wno-narrowing -std=gnu++11"
+    make CXXFLAGS="-Wno-narrowing -std=c++11"
     sudo make install
 
 If you want to use the JACK and libVLC input, please use


### PR DESCRIPTION
I coundn't build it with gcc v5.2.0. A quick-fix is to add the flags: -Wno-narrowing -std=c++11 as in my edit.
